### PR TITLE
Add gitlab.com/the-muppets as additional source for proprietary files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ ENV OTA_URL ''
 ENV USER_NAME 'LineageOS Buildbot'
 ENV USER_MAIL 'lineageos-buildbot@docker.host'
 
-# Include proprietary files, downloaded automatically from github.com/TheMuppets/
+# Include proprietary files, downloaded automatically from github.com/TheMuppets/ and gitlab.com/the-muppets/
 # Only some branches are supported
 ENV INCLUDE_PROPRIETARY true
 
@@ -123,7 +123,7 @@ ENV OPENDELTA_BUILDS_JSON ''
 # You can optionally specify a USERSCRIPTS_DIR volume containing these scripts:
 #  * begin.sh, run at the very beginning
 #  * before.sh, run after the syncing and patching, before starting the builds
-#  * pre-build.sh, run before the build of every device 
+#  * pre-build.sh, run before the build of every device
 #  * post-build.sh, run after the build of every device
 #  * end.sh, run at the very end
 # Each script will be run in $SRC_DIR and must be owned and writeable only by

--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ three ways:
 
  * by [pulling them from a running LineageOS][blobs-pull]
  * by [extracting them from a LineageOS ZIP][blobs-extract]
- * by downloading them from [TheMuppets repos][blobs-themuppets] (unofficial)
+ * by downloading them from TheMuppets [GitHub][blobs-themuppets] and
+   [GitLab][blobs-the-muppets] repositories (unofficial)
 
 The third way is the easiest one and is enabled by default; if you're OK with
 that just move on, otherwise set `INCLUDE_PROPRIETARY (true)` to `false` and
@@ -306,6 +307,7 @@ docker run \
 [blobs-pull]: https://wiki.lineageos.org/devices/bacon/build#extract-proprietary-blobs
 [blobs-extract]: https://wiki.lineageos.org/extracting_blobs_from_zips.html
 [blobs-themuppets]: https://github.com/TheMuppets/manifests
+[blobs-the-muppets]: https://gitlab.com/the-muppets/manifest
 [lineageota]: https://github.com/julianxhokaxhiu/LineageOTA
 [los-extras]: https://download.lineageos.org/extras
 [dockerfile]: Dockerfile

--- a/src/build.sh
+++ b/src/build.sh
@@ -70,6 +70,8 @@ if [ "$LOCAL_MIRROR" = true ]; then
   rm -f .repo/local_manifests/proprietary.xml
   if [ "$INCLUDE_PROPRIETARY" = true ]; then
     wget -q -O .repo/local_manifests/proprietary.xml "https://raw.githubusercontent.com/TheMuppets/manifests/mirror/default.xml"
+    /root/build_manifest.py --remote "https://gitlab.com" --remotename "gitlab_https" \
+      "https://gitlab.com/the-muppets/manifest/raw/mirror/default.xml" .repo/local_manifests/proprietary_gitlab.xml
   fi
 
   echo ">> [$(date)] Syncing mirror repository" | tee -a "$repo_log"
@@ -127,6 +129,8 @@ for branch in ${BRANCH_NAME//,/ }; do
         echo ">> [$(date)] Can't find a matching branch on github.com/TheMuppets, using $themuppets_branch"
       fi
       wget -q -O .repo/local_manifests/proprietary.xml "https://raw.githubusercontent.com/TheMuppets/manifests/$themuppets_branch/muppets.xml"
+      /root/build_manifest.py --remote "https://gitlab.com" --remotename "gitlab_https" \
+        "https://gitlab.com/the-muppets/manifest/raw/$themuppets_branch/muppets.xml" .repo/local_manifests/proprietary_gitlab.xml
     fi
 
     echo ">> [$(date)] Syncing branch repository" | tee -a "$repo_log"
@@ -409,4 +413,3 @@ if [ -f /root/userscripts/end.sh ]; then
   echo ">> [$(date)] Running end.sh"
   /root/userscripts/end.sh
 fi
-

--- a/src/build_manifest.py
+++ b/src/build_manifest.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+#
+# Copyright (C) 2019 Nicola Corna <nicola@corna.info>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from xml.dom import minidom
+import xml.etree.ElementTree as ET
+import argparse
+
+try:
+    from urllib.request import urlopen
+except ImportError:
+    from urllib2 import urlopen
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Build an Android repo manifest')
+    parser.add_argument('url', type=str, help='URL of the source manifest')
+    parser.add_argument('out', type=str, help='Output path')
+    parser.add_argument('--remote', type=str, help='Remote URL')
+    parser.add_argument('--remotename', type=str, help='Remote name')
+
+    args = parser.parse_args()
+
+    source_manifest = urlopen(args.url).read()
+
+    xmlin = ET.fromstring(source_manifest)
+    xmlout = ET.Element("manifest")
+
+    if args.remote:
+        ET.SubElement(xmlout, 'remote', attrib={"name": args.remotename,
+                                                "fetch": args.remote})
+
+    for child in xmlin:
+        if child.tag == "project":
+            attributes = {}
+            attributes["name"] = child.attrib["name"]
+
+            if "path" in child.attrib:
+                attributes["path"] = child.attrib["path"]
+
+            if args.remote:
+                attributes["remote"] = args.remotename
+
+            ET.SubElement(xmlout, 'project', attrib=attributes)
+
+    xmlstr = minidom.parseString(ET.tostring(xmlout)).toprettyxml(indent="  ", encoding="UTF-8")
+    with open(args.out, "w") as f:
+        f.write(xmlstr)


### PR DESCRIPTION
Manifests can not be used as-is, as they have some incompatibilities
(like the re-define of the already existing "gitlab" remote) with the
build system.